### PR TITLE
Added a protected property to configure the properties that can be se…

### DIFF
--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -301,6 +301,18 @@ class Message implements JsonSerializable, Serializable
      */
     protected $emailPattern = self::EMAIL_PATTERN;
 
+    /** 
+     * Properties that could be serialized
+     * 
+     * @var string[] 
+     */
+    protected $serializableProperties = [
+        'to', 'from', 'sender', 'replyTo', 'cc', 'bcc', 'subject',
+        'returnPath', 'readReceipt', 'emailFormat', 'emailPattern', 'domain',
+        'attachments', 'messageId', 'headers', 'appCharset', 'charset', 'headerCharset',
+        'textMessage', 'htmlMessage',
+    ];
+
     /**
      * Constructor
      *
@@ -1849,15 +1861,8 @@ class Message implements JsonSerializable, Serializable
      */
     public function jsonSerialize(): array
     {
-        $properties = [
-            'to', 'from', 'sender', 'replyTo', 'cc', 'bcc', 'subject',
-            'returnPath', 'readReceipt', 'emailFormat', 'emailPattern', 'domain',
-            'attachments', 'messageId', 'headers', 'appCharset', 'charset', 'headerCharset',
-            'textMessage', 'htmlMessage',
-        ];
-
         $array = [];
-        foreach ($properties as $property) {
+        foreach ($this->serializableProperties as $property) {
             $array[$property] = $this->{$property};
         }
 

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -304,7 +304,7 @@ class Message implements JsonSerializable, Serializable
     /**
      * Properties that could be serialized
      *
-     * @var string[]
+     * @var array<string>
      */
     protected $serializableProperties = [
         'to', 'from', 'sender', 'replyTo', 'cc', 'bcc', 'subject',

--- a/src/Mailer/Message.php
+++ b/src/Mailer/Message.php
@@ -301,10 +301,10 @@ class Message implements JsonSerializable, Serializable
      */
     protected $emailPattern = self::EMAIL_PATTERN;
 
-    /** 
+    /**
      * Properties that could be serialized
-     * 
-     * @var string[] 
+     *
+     * @var string[]
      */
     protected $serializableProperties = [
         'to', 'from', 'sender', 'replyTo', 'cc', 'bcc', 'subject',

--- a/tests/TestCase/Mailer/MessageTest.php
+++ b/tests/TestCase/Mailer/MessageTest.php
@@ -1306,6 +1306,10 @@ HTML;
     public function testSerialization(): void
     {
         $message = new Message();
+        $reflection = new \ReflectionClass($message);
+        $property = $reflection->getProperty('serializableProperties');
+        $property->setAccessible(true);
+        $serializableProperties = $property->getValue($message);
 
         $message
             ->setSubject('I haz Cake')
@@ -1317,6 +1321,12 @@ HTML;
 
         $string = serialize($message);
         $this->assertStringContainsString('text message', $string);
+
+        $this->assertIsArray($serializableProperties);
+        $this->assertContains('subject', $serializableProperties);
+        $this->assertContains('emailFormat', $serializableProperties);
+        $this->assertContains('textMessage', $serializableProperties);
+        $this->assertContains('htmlMessage', $serializableProperties);
 
         /** @var \Cake\Mailer\Message $message */
         $message = unserialize($string);


### PR DESCRIPTION
With this new change it is possible to better extend the Mailer/Message class to be able to customize the properties that can be serializable.

For example:
```php
<?php
declare(strict_types=1);

namespace App\Mailer;

use Cake\Mailer\Message;

class CustomMessage extends Message {
    protected $serializableProperties = [
        'to', 'from', 'sender', 'replyTo', 'cc', 'bcc', 'subject',
        'returnPath', 'readReceipt', 'emailFormat', 'emailPattern', 'domain',
        'attachments', 'messageId', 'headers', 'appCharset', 'charset', 'headerCharset',
        'textMessage'
    ];
}
```